### PR TITLE
VCリージョン変更の挙動変更

### DIFF
--- a/RaumiDiscord.Core.Server/DiscordBot/Deltaraumi_Discordbot.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Deltaraumi_Discordbot.cs
@@ -144,11 +144,9 @@ namespace RaumiDiscord.Core.Server.DiscordBot
         private async Task MessageReceivedAsync(SocketMessage message)
         {
             Console.WriteLine($"*ReceivedServer:");
-            Console.WriteLine($"|ReceivedChannel:{message.Channel}");
-            Console.WriteLine($"|ReceivedUser:{message.Author}");
-            Console.WriteLine($"|MessageReceived:{message.Content}");
-            Console.WriteLine($"|CleanContent:{message.CleanContent}");
+            Console.WriteLine($"|ReceivedChannel:{message.Channel}\n|ReceivedUser:{message.Author}\n|MessageReceived:{message.Content}\n|CleanContent:{message.CleanContent}\n");
             Console.WriteLine($"|EmbedelMessage:{message.Embeds}");
+
             //ボットは自分自身に応答してはなりません。
             if (message.Author.Id == _client.CurrentUser.Id)
                 return;
@@ -166,6 +164,7 @@ namespace RaumiDiscord.Core.Server.DiscordBot
 
             try
             {
+                //最クロマティック複雑度が高く、保守用意性が50切ってるので要修正
                 string contentbase = "@Raumi#1195 *";
                 switch (message.CleanContent)
                 {

--- a/RaumiDiscord.Core.Server/DiscordBot/Services/VoiceRtcregionService.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Services/VoiceRtcregionService.cs
@@ -69,7 +69,7 @@ namespace RaumiDiscord.Core.Server.DiscordBot.Services
 
         internal static async Task HandleRTCSettingsCommand(SocketSlashCommand command, string region_code, SocketVoiceChannel cmd_vcChannel)
         {
-            
+            //要注意：保守容易性指数が50を切っている1％以上の確率でバグを引くおそれあり
             Console.WriteLine(new LogMessage(LogSeverity.Info, "RTCfunc", $"{region_code}" ));
 
 
@@ -99,8 +99,7 @@ namespace RaumiDiscord.Core.Server.DiscordBot.Services
             {
                 
                 await command.RespondAsync($"指定されたIDのボイスチャンネルが見つかりません。\n" +
-                    $"ボイスチャンネルに入ってからコマンドを実行するかVCを指定してください。\n" +
-                    $"現在のチャンネルID:null",ephemeral:true);
+                    $"ボイスチャンネルに入ってからコマンドを実行するかVCを指定してください。\n",ephemeral:true);
                 return;
             }
 

--- a/RaumiDiscord.Core.Server/Program.cs
+++ b/RaumiDiscord.Core.Server/Program.cs
@@ -40,3 +40,4 @@ Task task = Task.Run(async () => {
 });
 
 app.Run();
+//


### PR DESCRIPTION
変更されたコマンドの挙動
/vc-region region: auto　使用者がVCにいる場合自動的にチャンネルが追加されます。いない場合はオプションを使うように促します。
/vc-region region: auto target: VoiceChannnel　自由に追加できます。
現在チャンネル編集者権限持ちとホワイトリストのみがこのコマンドを実行する権限を持っています。

廃止したメンションコマンド
@Raumi#1195 VCADD
@Raumi#1195 Discordリージョン*
現在は案内が流されるだけです。