### PR TITLE
モジュールベースへの変更の準備+実装

### DIFF
--- a/RaumiDiscord.Core.Server/DiscordBot/InteractionHandler.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/InteractionHandler.cs
@@ -1,0 +1,124 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using System.Reflection;
+using static Nett.TomlObjectFactory;
+
+namespace RaumiDiscord.Core.Server.DiscordBot
+{
+    internal class InteractionHandler
+    {
+        private readonly DiscordSocketClient _client;
+        private readonly InteractionService _handler;
+        private readonly IServiceProvider _services;
+        private readonly List<ulong> _guildIds; // ギルドIDリスト
+
+        //private readonly IConfiguration _configuration;
+
+        public InteractionHandler(DiscordSocketClient client, InteractionService handler, IServiceProvider services, IConfiguration config, List<ulong>? guildIds)
+        {
+            _client = client;
+            this._handler = handler;
+            _services = services;
+            _guildIds = guildIds;
+            //_configuration = config;
+        }
+
+        public static Task Log(LogMessage msg) => Task.Run(() => Console.WriteLine(msg.ToString()));
+
+        public async Task InitializeAsync()
+        {
+            // クライアントの準備ができたら処理し、コマンドを登録できるようにします。
+            _client.Ready += RegisterCommandsAsync;
+            _handler.Log += LogAsync;
+
+            // InteractionModuleBase<T> を継承するパブリックモジュールを InteractionService に追加します
+            await _handler.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
+
+            // InteractionCreated ペイロードを処理して Interactions コマンドを実行します
+            _client.InteractionCreated += HandleInteraction;
+
+            // コマンド実行の結果も処理します
+            _handler.InteractionExecuted += HandleInteractionExecute;
+            await Log(new LogMessage(LogSeverity.Info, "InteractionHandler", $"Completed"));
+        }
+
+        private Task LogAsync(LogMessage log)
+        {
+            Console.WriteLine(new LogMessage(LogSeverity.Info, "Log", $"{log}"));
+            return Task.CompletedTask;
+        }
+
+        private async Task RegisterCommandsAsync()
+        {
+            // グローバルコマンド登録
+            await RegisterGlobalCommandsAsync();
+
+            // ギルドごとのコマンド登録
+            //foreach (var guildId in _guildIds)
+            //{
+            //    await RegisterGuildCommandsAsync(guildId);
+            //}
+        }
+
+        private async Task RegisterGlobalCommandsAsync()
+        {
+            await _handler.RegisterCommandsGloballyAsync();
+            await Log(new LogMessage(LogSeverity.Info, "InteractionHandler", "Registered global commands"));
+        }
+
+        public async Task RegisterGuildCommandsAsync(ulong guildId)
+        {
+            await _handler.RegisterCommandsToGuildAsync(guildId);
+            await Log(new LogMessage(LogSeverity.Info, "InteractionHandler", $"Registered commands for guild: {guildId}"));
+        }
+
+        private async Task HandleInteraction(SocketInteraction interaction)
+        {
+            try
+            {
+                // InteractionModuleBase<T> モジュールのジェネリック型パラメータに一致する実行コンテキストを作成します。
+                var context = new SocketInteractionContext(_client, interaction);
+
+                // 受信したコマンドを実行します。
+                var result = await _handler.ExecuteCommandAsync(context, _services);
+
+                // InteractionFramework の非同期性により、ここでの結果は常に成功になる可能性があります。
+                // そのため、InteractionExecuted イベントも処理する必要があります。
+                if (!result.IsSuccess)
+                    switch (result.Error)
+                    {
+                        case InteractionCommandError.UnmetPrecondition:
+                            // 埋め込む
+                            await Log(new LogMessage(LogSeverity.Warning, "InteractionHandler", $"{result.ErrorReason}"));
+                            break;
+                        default:
+                            break;
+                    }
+            }
+            catch
+            {
+                // スラッシュコマンドの実行が失敗した場合、元の対話確認が残る可能性が高くなります。元の対話確認を削除することをおすすめします。
+                // 応答を返すか、少なくともコマンドの実行中に問題が発生したことをユーザーに知らせます。
+                if (interaction.Type is InteractionType.ApplicationCommand)
+                    await interaction.GetOriginalResponseAsync().ContinueWith(async (msg) => await msg.Result.DeleteAsync());
+            }
+        }
+
+        private Task HandleInteractionExecute(ICommandInfo commandInfo, IInteractionContext context, Discord.Interactions.IResult result)
+        {
+            if (!result.IsSuccess)
+                switch (result.Error)
+                {
+                    case InteractionCommandError.UnmetPrecondition:
+                        // implement
+                        Log(new LogMessage(LogSeverity.Warning, "InteractionHandler", $"{result.ErrorReason}"));
+                        break;
+                    default:
+                        break;
+                }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/MessageCommand/Global/MentionRespondModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/MessageCommand/Global/MentionRespondModule.cs
@@ -1,0 +1,27 @@
+﻿using Discord;
+using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.MessageCommand
+{
+    public class MentionRespondModule
+    {
+        [MessageCommand("@Raumi#1195")]
+        public async Task MentiononlyCommand(IMessage message)
+        {
+            string contentbase = "@Raumi#1195 *";
+            switch (message.CleanContent)
+            {
+                case "@Raumi#1195":
+                    await message.Channel.SendMessageAsync("なに...？");
+                    break;
+
+                case string match when System.Text.RegularExpressions.Regex.IsMatch(message.CleanContent, contentbase):
+
+                    await message.Channel.SendMessageAsync("該当するメッセージコマンドはないっぽい…");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/BookmarkModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/BookmarkModule.cs
@@ -1,0 +1,13 @@
+﻿using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class BookmarkModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        [SlashCommand("hoyocode", "HoYoverseで使えるギフトコードを出力します")]
+        public async Task HoYoCode()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/BotInfoModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/BotInfoModule.cs
@@ -1,0 +1,27 @@
+﻿using Discord.Commands;
+using Discord.Interactions;
+using System.ComponentModel;
+using System.Reflection.Metadata;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class BotInfoModule : InteractionModuleBase<SocketInteractionContext>
+    {
+
+        public InteractionService Commands { get; set; }
+
+        private InteractionHandler handler;
+
+        public BotInfoModule()
+        {
+
+        }
+
+
+        [SlashCommand("ping", "pingをします")]
+        public async Task PingCommand()
+        {
+            await RespondAsync($"DiscordGateway:{Context.Client.Latency}ms");
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/CardGenerateModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/CardGenerateModule.cs
@@ -1,0 +1,13 @@
+﻿using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class CardGenerateModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        [SlashCommand("名刺", "名刺を出力します。この機能で出力したものはあくまで交友として使ってください。")]
+        public async Task CardGenerate()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/VoiceChannelJoinModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/VoiceChannelJoinModule.cs
@@ -1,0 +1,13 @@
+﻿using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class VoiceChannelJoinModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        [SlashCommand("join", "BOTをボイスチャンネルに呼び出す")]
+        public async Task BotJoin()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/VoiceChannelLeaveModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/VoiceChannelLeaveModule.cs
@@ -1,0 +1,13 @@
+﻿using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class VoiceChannelLeaveModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        [SlashCommand("leave", "BOTをVCから切断します")]
+        public async Task BotLeave()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/WebtoolsModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Global/WebtoolsModule.cs
@@ -1,0 +1,13 @@
+﻿using Discord.Interactions;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Global
+{
+    public class WebtoolsModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        [SlashCommand("webtools", "Webダッシュボードへ案内されます。(未実装)")]
+        public async Task WebDashbordLink()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Local/VoiceChangeRegionModule.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Modules/SlashCommand/Local/VoiceChangeRegionModule.cs
@@ -1,0 +1,94 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+
+namespace RaumiDiscord.Core.Server.DiscordBot.Modules.SlashCommand.Local
+{
+    //public class VoiceChangeRegionModule
+
+    public class VoiceChangeRegionModule : InteractionModuleBase<SocketInteractionContext>
+    {
+        private static readonly Dictionary<string, string?> RegionOptions = new()
+        {
+            { "auto", null},
+            { "brazil", "brazil"},
+            { "hongkong", "hongkong"},
+            { "india", "india"},
+            { "japan", "japan"},
+            { "rotterdam", "rotterdam"},
+            { "russia", "russia"},
+            { "singapore", "singapore"},
+            { "southafrica", "southafrica"},
+            { "us-central", "us-central"},
+            { "us-east", "us-east"},
+            { "us-south", "us-south"},
+            { "us-west", "us-west"}
+        };
+
+        [SlashCommand("vc-region", "VCのリージョンを変更します。")]
+        public async Task SetVoiceCommand(
+            [Summary("region", "リージョンを選択")]
+            [Choice("Auto", "auto")]
+            [Choice("Brazil", "brazil")]
+            [Choice("HongKong", "hongkong")]
+            [Choice("India", "india")]
+            [Choice("Japan", "japan")]
+            [Choice("Rotterdam", "rotterdam")]
+            [Choice("Russia", "russia")]
+            [Choice("Singapore", "singapore")]
+            [Choice("SouthAfrica", "southafrica")]
+            [Choice("US Central", "us-central")]
+            [Choice("US East", "us-east")]
+            [Choice("US South", "us-south")]
+            [Choice("US West", "us-west")]
+            string region,
+
+            [Summary("voice_channel", "VCを選択(VCに入っていれば省略可)")]
+            [Autocomplete(typeof(VoiceChannelAutocompleteHandler))]
+            SocketVoiceChannel? voiceChannel = null)
+        {
+            var user = Context.User as SocketGuildUser;
+            if (user == null || (!user.GuildPermissions.ManageChannels && !user.Roles.Any(r => r.Permissions.ManageChannels)))
+            {
+                await RespondAsync("このコマンドを使用するのに必要な権限がありません。", ephemeral: true);
+                return;
+            }
+
+            var userVoiceChannel = (user.VoiceChannel as SocketVoiceChannel);
+            if (voiceChannel == null)
+            {
+                voiceChannel = userVoiceChannel;
+            }
+
+            if (voiceChannel == null)
+            {
+                await RespondAsync("変更できるボイスチャネルが見つかりません。", ephemeral: true);
+                return;
+            }
+
+            string selectedRegion = RegionOptions[region];
+            await voiceChannel.ModifyAsync(vc => vc.RTCRegion = selectedRegion);
+            await RespondAsync($"チャンネル `{voiceChannel.Name}` のリージョンを `{selectedRegion ??"Auto"}`に変更しました。");
+        }
+    }
+
+    public class VoiceChannelAutocompleteHandler : AutocompleteHandler
+    {
+        public override Task<AutocompletionResult> GenerateSuggestionsAsync(
+            IInteractionContext context,
+            IAutocompleteInteraction autocompleteInteraction,
+            IParameterInfo parameter,
+            IServiceProvider services)
+        {
+            var guild = (context.Guild as SocketGuild);
+            if (guild == null)
+                return Task.FromResult(AutocompletionResult.FromSuccess());
+
+            var voiceChannels = guild.VoiceChannels
+                .Select(vc => new AutocompleteResult(vc.Name, vc.Id.ToString()))
+                .ToList();
+
+            return Task.FromResult(AutocompletionResult.FromSuccess(voiceChannels));
+        }
+    }
+}

--- a/RaumiDiscord.Core.Server/DiscordBot/Services/ComponentInteractionService.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Services/ComponentInteractionService.cs
@@ -106,7 +106,6 @@ namespace RaumiDiscord.Core.Server.DiscordBot.Services
                             break;
 
                         case "serverstat":
-                           
                             DateTime localuptime = configuration.Setting.UpTime;
                             DateTime utcUptime = localuptime.ToUniversalTime();
                             long unixTime = new DateTimeOffset(utcUptime).ToUnixTimeSeconds(); 
@@ -114,7 +113,7 @@ namespace RaumiDiscord.Core.Server.DiscordBot.Services
                             builder.WithAuthor(component.User);
                             builder.WithTitle("サーバーの状態");
                             builder.WithDescription(
-                                "バージョン：0.1.0.12 (2025/02/3-0:10)\n " +
+                                "バージョン：0.1.0.18 (2025/02/6-09:55)\n " +
                                 "外部連携：null\n" +
                                 "読み上げエンジン：null\n" +
                                 "WebGUI：null" +

--- a/RaumiDiscord.Core.Server/DiscordBot/Services/SlashCommandInterationService.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Services/SlashCommandInterationService.cs
@@ -41,7 +41,7 @@ class SlashCommandInterationService
         this.DbContext = dbContext;
         this.Client = client;
         this.LoggingService = logger;
-        client.Ready += Client_GlobalAvailadle;
+        //client.Ready += Client_GlobalAvailadle;
         client.GuildAvailable += Client_GuildAvailadle;
         client.SlashCommandExecuted += Client_SlashCommandExcuted;
     }
@@ -59,9 +59,9 @@ class SlashCommandInterationService
             case "pat":
                 await Pat(command_arg);
                 break;
-            case "vc-region":
-                await VcRegion(command_arg);
-                break;
+            //case "vc-region":
+            //    await VcRegion(command_arg);
+            //    break;
             case "join":
                 await JoinVC(command_arg);
                 break;
@@ -82,7 +82,7 @@ class SlashCommandInterationService
             {
                 await guild_arg.DeleteApplicationCommandsAsync();
                 await guild_arg.BulkOverwriteApplicationCommandAsync(commands);
-                command_GuildAvailadle = false;
+                //command_GuildAvailadle = false;
             }
             else
             {
@@ -126,6 +126,8 @@ class SlashCommandInterationService
             Environment.Exit(1);
         }
     }
+    //使われてないため次のバージョンで削除
+
     /// <summary>
     /// ギルドコマンドを設定するためのリストが作られます。
     /// </summary>
@@ -147,40 +149,40 @@ class SlashCommandInterationService
         commands.Add(patBuilder);
         #endregion
 
-        #region /VcRegion
-        SlashCommandBuilder vcRegionBuilder = new SlashCommandBuilder();
-        vcRegionBuilder.WithName("vc-region").WithDescription("VCの接続リージョンを変更する")
-            .AddOption(new SlashCommandOptionBuilder()
-            .WithName("region")
-            .WithDescription("変更するVCの地域")
-            .WithRequired(true)
-            .AddChoice("auto", "auto")
-            .AddChoice("brazil", "brazil")
-            .AddChoice("hongkong", "hongkong")
-            .AddChoice("india", "india")
-            .AddChoice("japan", "japan")
-            .AddChoice("rotterdam", "rotterdam")
-            .AddChoice("russia", "russia")
-            .AddChoice("singapore", "singapore")
-            .AddChoice("southafrica", "southafrica")
-            .AddChoice("us-central", "us-central")
-            .AddChoice("us-east", "us-east")
-            .AddChoice("us-south", "us-south")
-            .AddChoice("us-west", "us-west")
-            .WithType(ApplicationCommandOptionType.String)
-            )
-                .AddOption(new SlashCommandOptionBuilder()
-                .WithName("target")
-                .WithDescription("変更を加えるチャンネル")
-                .WithRequired(false)
-                .WithType(ApplicationCommandOptionType.Channel)
-                .AddChannelType(ChannelType.Voice)  // ボイスチャンネルのみ指定
-            );
+        //#region /VcRegion
+        //SlashCommandBuilder vcRegionBuilder = new SlashCommandBuilder();
+        //vcRegionBuilder.WithName("vc-region").WithDescription("VCの接続リージョンを変更する")
+        //    .AddOption(new SlashCommandOptionBuilder()
+        //    .WithName("region")
+        //    .WithDescription("変更するVCの地域")
+        //    .WithRequired(true)
+        //    .AddChoice("auto", "auto")
+        //    .AddChoice("brazil", "brazil")
+        //    .AddChoice("hongkong", "hongkong")
+        //    .AddChoice("india", "india")
+        //    .AddChoice("japan", "japan")
+        //    .AddChoice("rotterdam", "rotterdam")
+        //    .AddChoice("russia", "russia")
+        //    .AddChoice("singapore", "singapore")
+        //    .AddChoice("southafrica", "southafrica")
+        //    .AddChoice("us-central", "us-central")
+        //    .AddChoice("us-east", "us-east")
+        //    .AddChoice("us-south", "us-south")
+        //    .AddChoice("us-west", "us-west")
+        //    .WithType(ApplicationCommandOptionType.String)
+        //    )
+        //        .AddOption(new SlashCommandOptionBuilder()
+        //        .WithName("target")
+        //        .WithDescription("変更を加えるチャンネル")
+        //        .WithRequired(false)
+        //        .WithType(ApplicationCommandOptionType.Channel)
+        //        .AddChannelType(ChannelType.Voice)  // ボイスチャンネルのみ指定
+        //    );
 
 
 
-        commands.Add(vcRegionBuilder);
-        #endregion
+        //commands.Add(vcRegionBuilder);
+        //#endregion
 
         #region /Join
         SlashCommandBuilder joinBuilder = new SlashCommandBuilder();
@@ -315,80 +317,7 @@ class SlashCommandInterationService
         await DbContext.SaveChangesAsync();
     }
 
-    public async Task VcRegion(SocketSlashCommand command_arg)
-    {
-        string? cmd_region = command_arg.Data.Options.First(op => op.Name == "region").Value.ToString();
-        SocketSlashCommandDataOption? cmd_vcChannel = command_arg.Data.Options.FirstOrDefault(op => op.Name == "target");
-
-        //string ? region_code;
-        SocketVoiceChannel? voiceChannel = null;
-
-        if (cmd_vcChannel != null)
-        {
-            voiceChannel = cmd_vcChannel.Value as SocketVoiceChannel;
-
-            //static Array AllowedRegionCodeへの変更が推奨されている
-            //注意：targetがnull以外の場合実行されるコードのため削ってしまうと指定ができない
-        }
-
-        await listVoiceRegion(voiceChannel);
-        try
-        {
-            //Complex Method ：https://www.codefactor.io/repository/github/raumigit/raumidiscord.core/file/master/RaumiDiscord.Core.Server/DiscordBot/Services/SlashCommandInterationService.cs
-            switch (cmd_region)
-            {
-                case "auto":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "brazil":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "hongkong":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "india":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "japan":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "rotterdam":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "russia":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "singapore":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "southafrica":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "us-central":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "us-east":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "us-south":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-                case "us-west":
-                    await VoicertcregionService.HandleRTCSettingsCommand(command_arg, cmd_region, voiceChannel);
-                    break;
-
-                default:
-                    await LoggingService.LogGeneral($"コマンドオプションが不明(E-R4007)引数：{cmd_region}", LoggingService.LogGeneralSeverity.Warning);
-                    break;
-            }
-        }
-        catch (Exception e)
-        {
-            await LoggingService.LogGeneral($"エラーが発生しました(E-R4007)", severity: LoggingService.LogGeneralSeverity.Error);
-            await LoggingService.LogGeneral(e.ToString(), LoggingService.LogGeneralSeverity.Fatal);
-            await LoggingService.LogGeneral("");
-        }
-    }
+    
 
 
     public async Task listVoiceRegion(SocketVoiceChannel? voiceChannel)

--- a/RaumiDiscord.Core.Server/DiscordBot/Services/VoiceRtcregionService.cs
+++ b/RaumiDiscord.Core.Server/DiscordBot/Services/VoiceRtcregionService.cs
@@ -19,107 +19,107 @@ namespace RaumiDiscord.Core.Server.DiscordBot.Services
         };
         
 
-        public static async void SetRTCRegion(SocketMessage message, string region)
-        {
-            ulong channelId = Deltaraumi_Discordbot.vc_chid;
+        //public static async void SetRTCRegion(SocketMessage message, string region)
+        //{
+        //    ulong channelId = Deltaraumi_Discordbot.vc_chid;
 
-            //if (!ulong.TryParse(parts[1], out ulong channelId))
-            //{
-            //    await message.Channel.SendMessageAsync("チャンネルIDが無効です。");
-            //    return;
-            //}
+        //    //if (!ulong.TryParse(parts[1], out ulong channelId))
+        //    //{
+        //    //    await message.Channel.SendMessageAsync("チャンネルIDが無効です。");
+        //    //    return;
+        //    //}
 
-            //var region ;
-            var guild = (message.Channel as SocketGuildChannel)?.Guild;
+        //    //var region ;
+        //    var guild = (message.Channel as SocketGuildChannel)?.Guild;
 
-            if (guild == null)
-            {
-                await message.Channel.SendMessageAsync("サーバー内でコマンドを実行してください。");
-                return;
-            }
+        //    if (guild == null)
+        //    {
+        //        await message.Channel.SendMessageAsync("サーバー内でコマンドを実行してください。");
+        //        return;
+        //    }
 
-            var channel = guild.GetVoiceChannel(channelId);
-            if (channel == null)
-            {
-                await message.Channel.SendMessageAsync("指定されたIDのボイスチャンネルが見つかりません。");
-                await message.Channel.SendMessageAsync($"現在のチャンネルID:{channelId}");
-                return;
-            }
+        //    var channel = guild.GetVoiceChannel(channelId);
+        //    if (channel == null)
+        //    {
+        //        await message.Channel.SendMessageAsync("指定されたIDのボイスチャンネルが見つかりません。");
+        //        await message.Channel.SendMessageAsync($"現在のチャンネルID:{channelId}");
+        //        return;
+        //    }
 
-            try
-            {
-                await channel.ModifyAsync(properties =>
-                {
-                    properties.RTCRegion = region == "auto" ? null : region;
-                });
-                if (region== null)
-                {
-                    await message.Channel.SendMessageAsync($"チャンネル `{channel.Name}` のリージョンを`AUTO`に変更しました。");
-                }
-                else
-                {
-                    await message.Channel.SendMessageAsync($"チャンネル `{channel.Name}` のリージョンを `{region}` に変更しました。");
-                }
-            }
-            catch (Exception ex)
-            {
-                await message.Channel.SendMessageAsync($"リージョン変更に失敗しました(E-4007): {ex.Message}");
-            }
-        }
+        //    try
+        //    {
+        //        await channel.ModifyAsync(properties =>
+        //        {
+        //            properties.RTCRegion = region == "auto" ? null : region;
+        //        });
+        //        if (region== null)
+        //        {
+        //            await message.Channel.SendMessageAsync($"チャンネル `{channel.Name}` のリージョンを`AUTO`に変更しました。");
+        //        }
+        //        else
+        //        {
+        //            await message.Channel.SendMessageAsync($"チャンネル `{channel.Name}` のリージョンを `{region}` に変更しました。");
+        //        }
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        await message.Channel.SendMessageAsync($"リージョン変更に失敗しました(E-4007): {ex.Message}");
+        //    }
+        //}
 
-        internal static async Task HandleRTCSettingsCommand(SocketSlashCommand command, string region_code, SocketVoiceChannel cmd_vcChannel)
-        {
-            //要注意：保守容易性指数が50を切っている1％以上の確率でバグを引くおそれあり
-            Console.WriteLine(new LogMessage(LogSeverity.Info, "RTCfunc", $"{region_code}" ));
-
-
-            var guildId = (command.Channel as SocketGuildChannel)?.Guild;
-            var guildUser = (SocketGuildUser)command.User;
-            //var vchannel = guildId.GetVoiceChannel(VoiceChannelId);
-            var userVoiceChannel = guildUser.VoiceChannel;
-            bool AllowRores = guildUser.Roles.Any(role => allowedRoleIds.Contains(role.Id));
-
-            if (!guildUser.GuildPermissions.ManageChannels && !AllowRores) 
-            {
-                await command.RespondAsync($"権限不足：大いなる力にはそれ相応の責任があるのです…", ephemeral: true);
-                return;
-            }
-            if (cmd_vcChannel != null)
-            {
-                ulong VoiceChannelId = cmd_vcChannel.Id;
-                Console.WriteLine($"引数で追加されました。{VoiceChannelId}");
-            }
-            if (cmd_vcChannel == null && userVoiceChannel != null)//
-            {
-                cmd_vcChannel = userVoiceChannel;
-                Console.WriteLine($"コマンド使用ユーザーのチャンネルを使って追加されました。{cmd_vcChannel}");
-            }
-            if (cmd_vcChannel == null)
-            {
-                await command.RespondAsync($"指定されたIDのボイスチャンネルが見つかりません。\n" +
-                    $"ボイスチャンネルに入ってからコマンドを実行するかVCを指定してください。\n",ephemeral:true);
-                return;
-            }
-
-            try
-            {
-                await cmd_vcChannel.ModifyAsync(properties => { properties.RTCRegion = region_code =="auto"?null:region_code; });
-                if (region_code == null)
-                {
-                    await command.RespondAsync($"チャンネル `{cmd_vcChannel.Name}` のリージョンを`AUTO`に変更しました。");
-                }
-                else
-                {
-                    await command.RespondAsync($"チャンネル `{cmd_vcChannel.Name}` のリージョンを `{region_code}` に変更しました。");
-                }
-            }
-            catch (Exception ex)
-            {
-                await command.RespondAsync($"リージョン変更に失敗しました(E-4007): {ex.Message}");
-            }
+        //internal static async Task HandleRTCSettingsCommand(SocketSlashCommand command, string region_code, SocketVoiceChannel cmd_vcChannel)
+        //{
+        //    //要注意：保守容易性指数が50を切っている1％以上の確率でバグを引くおそれあり
+        //    Console.WriteLine(new LogMessage(LogSeverity.Info, "RTCfunc", $"{region_code}" ));
 
 
-            //throw new NotImplementedException();
-        }
+        //    var guildId = (command.Channel as SocketGuildChannel)?.Guild;
+        //    var guildUser = (SocketGuildUser)command.User;
+        //    //var vchannel = guildId.GetVoiceChannel(VoiceChannelId);
+        //    var userVoiceChannel = guildUser.VoiceChannel;
+        //    bool AllowRores = guildUser.Roles.Any(role => allowedRoleIds.Contains(role.Id));
+
+        //    if (!guildUser.GuildPermissions.ManageChannels && !AllowRores) 
+        //    {
+        //        await command.RespondAsync($"権限不足：大いなる力にはそれ相応の責任があるのです…", ephemeral: true);
+        //        return;
+        //    }
+        //    if (cmd_vcChannel != null)
+        //    {
+        //        ulong VoiceChannelId = cmd_vcChannel.Id;
+        //        Console.WriteLine($"引数で追加されました。{VoiceChannelId}");
+        //    }
+        //    if (cmd_vcChannel == null && userVoiceChannel != null)//
+        //    {
+        //        cmd_vcChannel = userVoiceChannel;
+        //        Console.WriteLine($"コマンド使用ユーザーのチャンネルを使って追加されました。{cmd_vcChannel}");
+        //    }
+        //    if (cmd_vcChannel == null)
+        //    {
+        //        await command.RespondAsync($"指定されたIDのボイスチャンネルが見つかりません。\n" +
+        //            $"ボイスチャンネルに入ってからコマンドを実行するかVCを指定してください。\n",ephemeral:true);
+        //        return;
+        //    }
+
+        //    try
+        //    {
+        //        await cmd_vcChannel.ModifyAsync(properties => { properties.RTCRegion = region_code =="auto"?null:region_code; });
+        //        if (region_code == null)
+        //        {
+        //            await command.RespondAsync($"チャンネル `{cmd_vcChannel.Name}` のリージョンを`AUTO`に変更しました。");
+        //        }
+        //        else
+        //        {
+        //            await command.RespondAsync($"チャンネル `{cmd_vcChannel.Name}` のリージョンを `{region_code}` に変更しました。");
+        //        }
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        await command.RespondAsync($"リージョン変更に失敗しました(E-4007): {ex.Message}");
+        //    }
+
+
+        //    //throw new NotImplementedException();
+        //}
     }
 }

--- a/RaumiDiscord.Core.Server/Program.cs
+++ b/RaumiDiscord.Core.Server/Program.cs
@@ -22,7 +22,7 @@ var app = builder.Build();
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
-app.Urls.Add("http://localhost:6444");
+//app.Urls.Add("http://localhost:6444");
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -35,7 +35,8 @@ if (app.Environment.IsDevelopment())
 app.UseAuthorization();
 app.MapControllers();
 
-Task? task = Task.Run(async () => {
+Task? task = Task.Run(() =>
+{
     try
     {
         Console.WriteLine("Deltaraumi_loadŒÄ‚Ño‚µÏ‚Ý");
@@ -45,6 +46,8 @@ Task? task = Task.Run(async () => {
     {
         Console.Error.WriteLine(ex);
     }
+
+    return Task.CompletedTask;
 });
 
 app.Run();

--- a/RaumiDiscord.Core.Server/RaumiDiscord.Core.Server.csproj
+++ b/RaumiDiscord.Core.Server/RaumiDiscord.Core.Server.csproj
@@ -54,8 +54,6 @@
     <Folder Include="DeltaRaumi.Controller\Configuration\" />
     <Folder Include="DiscordBot\Configuration\" />
     <Folder Include="DiscordBot\Data\Interfaces\" />
-    <Folder Include="DiscordBot\Modules\SlashCommand\Global\" />
-    <Folder Include="DiscordBot\Modules\SlashCommand\Local\" />
     <Folder Include="Migrations\" />
   </ItemGroup>
 


### PR DESCRIPTION
目的：コマンドや応答をモジュールとして実装させコマンドの実装の煩雑さを軽減する
この実装により、モジュールベースのコマンドはグローバルコマンドとしての実装となるが、元よりギルド専用な理由もなかったため一部のスラッシュコマンドを除きほとんどをモジュール実装へ差し替える

現在の変更点
- メイン部分からInteractionCreatedAsyncの除去
- メッセージコマンドの大半を除去
- グローバルコマンドの登録部分を除去、代わりにモジュールで実装
- VCRegionをモジュールへ移植、ただし、完全な移植が完了していない
- 