### PR TITLE
Make build version field optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue report.yml
+++ b/.github/ISSUE_TEMPLATE/issue report.yml
@@ -118,7 +118,7 @@ body:
       label: "ビルド・バージョンを指定する"
       description: Botかダッシュボードに表示されているビルド・バージョンを教えてください。
     validations:
-      required: true
+      required: false
   - type: textarea
     id: environment-information
     attributes:


### PR DESCRIPTION
Changed the 'required' validation for the build version field from true to false.